### PR TITLE
Fix Arch dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,16 @@ First, install the following dependencies:
 sudo apt install build-essential bison flex libgmp3-dev libmpc-dev libmpfr-dev texinfo wget \
                    nasm mtools python3 python3-pip python3-parted scons dosfstools libguestfs-tools qemu-system-x86
 
-sudo pip3 install sh
-
 # Fedora:
 sudo dnf install gcc gcc-c++ make bison flex gmp-devel libmpc-devel mpfr-devel texinfo wget \
                    nasm mtools python3 python3-pip python3-pyparted python3-scons dosfstools guestfs-tools qemu-system-x86
 
-sudo pip3 install sh
-
 # Arch & Arch-based:
-paru -S gcc make bison flex libgmp-static libmpc mpfr texinfo nasm mtools qemu-system-x86 python3 python3-scons
-
-sudo pip3 install sh
+paru -S gcc make bison flex libgmp-static libmpc mpfr texinfo nasm mtools qemu-system-x86 python3 scons
 ```
 NOTE: to install all the required packages on Arch, you need an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers).
+
+Then you must run `python3 -m pip install -r requirements.txt`
 
 After that, run `scons toolchain`, this should download and build the required tools (binutils and GCC). If you encounter errors during this step, you might have to modify `build_scripts/config.mk` and try a different version of **binutils** and **gcc**. Using the same version as the one bundled with your distribution is your best bet.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+sh
+pyparted

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -61,7 +61,7 @@ DEPS_ARCH=(
     mtools
     qemu-system-x86
     python3-pip
-    python3-scons
+    scons
 )
 
 DEPS_SUSE=()


### PR DESCRIPTION
The package in the AUR for scons is called `scons`, and not `python3-scons`