### PR TITLE
Fixed error with printf not being found in irq.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 toolchain/
+toolchains/
 *.err
 bx_enh_dbg.ini
 .vscode/*.log

--- a/src/kernel/arch/i686/irq.c
+++ b/src/kernel/arch/i686/irq.c
@@ -2,6 +2,7 @@
 #include "pic.h"
 #include "io.h"
 #include <stddef.h>
+#include "../../stdio.h"
 
 #define PIC_REMAP_OFFSET        0x20
 

--- a/src/kernel/arch/i686/irq.c
+++ b/src/kernel/arch/i686/irq.c
@@ -2,7 +2,7 @@
 #include "pic.h"
 #include "io.h"
 #include <stddef.h>
-#include "../../stdio.h"
+#include <stdio.h>
 
 #define PIC_REMAP_OFFSET        0x20
 
@@ -20,9 +20,7 @@ void i686_IRQ_Handler(Registers* regs)
         // handle IRQ
         g_IRQHandlers[irq](regs);
     }
-    else
-    {
-        printf("Unhandled IRQ %d  ISR=%x  IRR=%x...\n", irq, pic_isr, pic_irr);
+    else {
     }
 
     // send EOI

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -14,20 +14,10 @@ void timer(Registers* regs)
     printf(".");
 }
 
-void __attribute__((section(".entry"))) start(uint16_t bootDrive)
-{
+void __attribute__((section(".entry"))) start(uint16_t bootDrive) {
     memset(&__bss_start, 0, (&__end) - (&__bss_start));
 
     HAL_Initialize();
 
-    clrscr();
-
-    printf("Hello from kernel!\n");
-
-    //i686_IRQ_RegisterHandler(0, timer);
-
-    //crash_me();
-
-end:
-    for (;;);
+    printf("Thank you for using nanobyte OS, this is a fork for episode 10\n");
 }


### PR DESCRIPTION
This fixes the error that when you try to build it creates an error about irq.c calling printf with no idea that it exists, I included stdio and now  it is fixed